### PR TITLE
fix: specify no-dump as a long flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,9 @@ fn cli() -> clap::Command<'static> {
                 )
                 .arg(
                     Arg::new("no-dump")
+                        .long("--no-write-schema")
+                        .env("NO_WRITE_SCHEMA")
+                        .action(clap::ArgAction::SetTrue)
                         .help("Do not write updated db/structure.sql when done"),
                 ),
         )


### PR DESCRIPTION
`--no-write-schema` is now valid

* without this, it acts as a positional argument
* takes the `NO_WRITE_SCHEMA` env var value by default