### PR TITLE
fix bugs, rationalize code, support unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "rmmm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmmm"
-version = "0.4.2"
+version = "0.5.0"
 description = "Rust MySQL Migration Manager"
 repository = "https://github.com/EasyPost/rmmm"
 authors = ["James Brown <jbrown@easypost.com>"]

--- a/src/migration_state.rs
+++ b/src/migration_state.rs
@@ -7,11 +7,11 @@ use anyhow::Context;
 use itertools::Itertools;
 use log::debug;
 
-const DEFAULT_EDITOR: &str = "nano";
+const DEFAULT_EDITOR: &str = "vim";
 
 #[derive(Debug)]
 pub(crate) struct Migration {
-    pub id: usize,
+    pub id: u32,
     pub label: Option<String>,
     pub upgrade_text: String,
     pub downgrade_text: Option<String>,
@@ -34,7 +34,7 @@ impl Migration {
         Ok(s.to_string())
     }
 
-    fn from_path(id: usize, p: &Path) -> anyhow::Result<Self> {
+    fn from_path(id: u32, p: &Path) -> anyhow::Result<Self> {
         let upgrade_file = std::fs::read_to_string(p)?;
         lazy_static::lazy_static! {
             static ref LABEL_RE: regex::Regex =
@@ -66,7 +66,7 @@ impl Migration {
 pub(crate) struct MigrationState {
     root_path: PathBuf,
     pub migrations: Vec<Migration>,
-    next_id: usize,
+    next_id: u32,
 }
 
 impl MigrationState {
@@ -137,15 +137,15 @@ impl MigrationState {
         Ok(())
     }
 
-    pub fn migrations_by_id(&self) -> BTreeMap<usize, &Migration> {
+    pub fn migrations_by_id(&self) -> BTreeMap<u32, &Migration> {
         self.migrations.iter().map(|m| (m.id, m)).collect()
     }
 
-    pub fn all_ids(&self) -> BTreeSet<usize> {
+    pub fn all_ids(&self) -> BTreeSet<u32> {
         self.migrations.iter().map(|m| m.id).collect()
     }
 
-    pub fn highest_id(&self) -> usize {
+    pub fn highest_id(&self) -> u32 {
         self.next_id - 1
     }
 


### PR DESCRIPTION
- support unix(/path) for go-style DATABASE_DSN
- vim is both more ubiquitous than nano and well known/expected to be the default editor
- remove prev_id in migration plan output, it didn't seem to contribute anything and just made the output confusing
- make sure the saved snapshot sql file ends in at least one newline, as is the POSIX "text file" way
- put a blank line between each table definition in the saved snapshot
- downgrade crashed because it was looking for the no-dump option which wasn't defined for downgrade
- don't try to "figure out" if the operator specified upgrade or downgrade, and then get it entirely wrong, be explicit and indicate that to the planner
- since we're not figuring out if this is an upgrade or downgrade, you can now downgrade to a specific version instead of it trying to *upgrade* to latest when trying to downgrade (or something, I'm not sure what the hell was happening with this code path, but it didn't do anything sane)
- refactor MigrationRunner plan into subfunctions to reduce cyclomatic complexity by not branching for upgrade or downgrade at every expression and statement
- use u32 instead of usize for migration ids: these are not pointers; 4B migrations is more than sufficient; the platform's pointer size shouldn't influence how many migrations this tool supports
- bump version 0.5.0